### PR TITLE
Fix config load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.1.dev3
 
+* Fix converting config options to dataframe when there are nested dictionaries in the config (e.g. `solve.solver_options`).
 * CLI: default to random port, making it easier to run several instances in parallel
 
 ## 0.1.1.dev2

--- a/src/calligraph/core.py
+++ b/src/calligraph/core.py
@@ -144,7 +144,6 @@ class ModelContainer:
 def filter_selectors(
     da: xr.DataArray, selectors: Dict[str, List[str]], additional_subset: Dict = None
 ) -> Dict[str, List[str]]:
-
     for k, v in selectors.items():
         assert isinstance(v, list)
 
@@ -189,13 +188,17 @@ def get_model_summary_df(model_container):
 
 def get_build_config_df(model_container):
     results = model_container.model._model_data
-    df = pd.DataFrame.from_dict(results.attrs["config"]["build"], orient="index")
+    df = pd.DataFrame.from_dict(
+        results.attrs["config"]["build"].as_dict_flat(), orient="index"
+    )
     return _clean_df(df)
 
 
 def get_solve_config_df(model_container):
     results = model_container.model._model_data
-    df = pd.DataFrame.from_dict(results.attrs["config"]["solve"], orient="index")
+    df = pd.DataFrame.from_dict(
+        results.attrs["config"]["solve"].as_dict_flat(), orient="index"
+    )
     return _clean_df(df)
 
 
@@ -245,7 +248,6 @@ def get_df_timeseries(
 
 
 def get_generic_df(model_container, variable, dropna=False, **selectors):
-
     da = model_container.model._model_data[variable]
 
     df = da.sel(filter_selectors(da, selectors)).to_dataframe()


### PR DESCRIPTION
Fixes #13 

You had `solver_options` in your solve config, which couldn't be handled due to their nested structure. I've gone for what might be considered a "dirty" fix of just flattening the nesting to have keys which represent the nesting with the dot notation.