### PR TITLE
Update version in __init__.py

### DIFF
--- a/src/calligraph/__init__.py
+++ b/src/calligraph/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1.dev4"
+__version__ = "0.1.1.dev5"
 
 import calligraph.cli
 import calligraph.core


### PR DESCRIPTION
The version is outdated, leading to 'dev4' being recognised as the version in pip